### PR TITLE
chore: disabled allowJs; added declaration options for outputting .d.ts files

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "allowJs": true,
     "baseUrl": ".",
     "esModuleInterop": true,
     "lib": [
@@ -12,6 +11,8 @@
     "moduleResolution": "node",
     "noImplicitAny": true,
     "outDir": "dist",
+    "declarationDir": "dist",
+    "declaration": true,
     "sourceMap": true,
     "strict": true,
     "target": "es2017"


### PR DESCRIPTION
It should be safe to remove `allowJs` here since there are no .js files. 